### PR TITLE
Pin TypeScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "lumenora",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "packages": {
+    "": {
+      "name": "lumenora",
+      "version": "1.0.0",
+      "devDependencies": {
+        "typescript": "~5.3.3"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "typescript": "^5.0.0",
+    "typescript": "~5.3.3",
     "@types/node": "^20.0.0",
     "jest": "^29.0.0",
     "ts-jest": "^29.0.0",
@@ -33,6 +33,8 @@
     "lint-staged": "^15.0.0"
   },
   "lint-staged": {
-    "*.{ts,js}": ["eslint --fix"]
+    "*.{ts,js}": [
+      "eslint --fix"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- pin typescript dev dependency at `~5.3.3`
- add minimal `package-lock.json`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: jest not found)*