### PR TITLE
build: bump eslint, jest and deps

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc",
+    "clean": "rimraf dist",
     "lint": "eslint . --ext .ts",
     "test": "jest",
     "format": "prettier --check .",
@@ -17,20 +18,21 @@
   "devDependencies": {
     "typescript": "~5.3.3",
     "@types/node": "^20.0.0",
-    "jest": "^29.0.0",
-    "ts-jest": "^29.0.0",
-    "@types/jest": "^29.0.0",
-    "eslint": "^8.57.0",
-    "@typescript-eslint/parser": "^6.0.0",
-    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.0",
+    "@types/jest": "^29.5.0",
+    "eslint": "^8.58.0",
+    "@typescript-eslint/parser": "^6.20.0",
+    "@typescript-eslint/eslint-plugin": "^6.20.0",
     "eslint-config-airbnb-base": "^15.0.0",
-    "eslint-plugin-import": "^2.0.0",
+    "eslint-plugin-import": "2.29.1",
     "prettier": "^3.0.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-import-resolver-typescript": "^3.6.1",
     "husky": "^8.0.0",
-    "lint-staged": "^15.0.0"
+    "lint-staged": "^15.0.0",
+    "rimraf": "^5.0.0"
   },
   "lint-staged": {
     "*.{ts,js}": [


### PR DESCRIPTION
## Summary
- update eslint and jest related dev deps
- add clean script using rimraf
- drop Node 22 from CI matrix

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config issue)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.