### PR TITLE
Update lint/test deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,23 @@
       "name": "lumenora",
       "version": "1.0.0",
       "devDependencies": {
-        "typescript": "~5.3.3"
+        "typescript": "~5.3.3",
+        "@types/node": "^20.0.0",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.2.0",
+        "@types/jest": "^29.5.0",
+        "eslint": "^8.58.0",
+        "@typescript-eslint/parser": "^6.21.0",
+        "@typescript-eslint/eslint-plugin": "^6.21.0",
+        "eslint-config-airbnb-base": "^15.0.0",
+        "eslint-plugin-import": "2.29.1",
+        "prettier": "^3.0.0",
+        "eslint-config-prettier": "^9.0.0",
+        "eslint-plugin-prettier": "^5.0.0",
+        "eslint-import-resolver-typescript": "^3.6.1",
+        "husky": "^8.0.0",
+        "lint-staged": "^15.0.0",
+        "rimraf": "^5.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "lint": "eslint . --ext .ts",
     "test": "jest",
     "format": "prettier --check .",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "lint:fix": "eslint . --ext .ts --fix",
+    "test:coverage": "jest --coverage"
   },
   "keywords": [],
   "author": "",
@@ -17,20 +19,21 @@
   "devDependencies": {
     "typescript": "~5.3.3",
     "@types/node": "^20.0.0",
-    "jest": "^29.0.0",
-    "ts-jest": "^29.0.0",
-    "@types/jest": "^29.0.0",
-    "eslint": "^8.57.0",
-    "@typescript-eslint/parser": "^6.0.0",
-    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.0",
+    "@types/jest": "^29.5.0",
+    "eslint": "^8.58.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
     "eslint-config-airbnb-base": "^15.0.0",
-    "eslint-plugin-import": "^2.0.0",
+    "eslint-plugin-import": "2.29.1",
     "prettier": "^3.0.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-import-resolver-typescript": "^3.6.1",
     "husky": "^8.0.0",
-    "lint-staged": "^15.0.0"
+    "lint-staged": "^15.0.0",
+    "rimraf": "^5.0.0"
   },
   "lint-staged": {
     "*.{ts,js}": [


### PR DESCRIPTION
## Summary
- update eslint, jest and ts-jest versions
- add lint:fix and test:coverage scripts
- update package lock

## Testing
- `npx eslint@8.58.0 . --ext .ts` *(fails: npm couldn't download packages)*
- `npx jest@29.7.0` *(fails: npm couldn't download packages)*